### PR TITLE
Fix vim.validate argument handling in setup function

### DIFF
--- a/lua/in-and-out/init.lua
+++ b/lua/in-and-out/init.lua
@@ -21,9 +21,11 @@ end
 local targets = { '"', "'", "(", ")", "{", "}", "[", "]", "`" }
 
 function M.setup(config)
-	vim.validate("config", config, "table", true)
-	vim.validate("config.targets", config.targets, "table", true)
-	vim.validate("config.additional_targets", config.additional_targets, "table", true)
+	vim.validate {
+		config = { config, "table", true },
+		targets = { config.targets, "table", true },
+		additional_targets = { config.additional_targets, "table", true }
+	}
 
 	if config and config.targets then
 		targets = config.targets


### PR DESCRIPTION
fix #7

# Problem
The plugin produced the following error:

```
Failed to run `config` for in-and-out.nvim

.../share/nvim/lazy/in-and-out.nvim/lua/in-and-out/init.lua:24: opt: expected table, got string
```

The issue was caused by incorrect usage of `vim.validate` in the `setup` function. Specifically, the function passed its arguments as individual parameters instead of using a table structure as required by `vim.validate`.

# Changes:

- Updated `vim.validate` calls in `lua/in-and-out/init.lua` to use the correct table syntax.

# Implementation check

I forked the `in-and-out.nvim` repository, applied the fix, and installed the plugin using `lazy.nvim` on Neovim v0.10.3. I confirmed that the error no longer occurs and the plugin works as expected with the provided configuration.

I also verified that the updated `vim.validate` raises an appropriate error when invalid configurations, such as `opts = { targets = 42 }`, are provided.